### PR TITLE
Only run flood plain calculations if dynamicFloodPlain is turned on

### DIFF
--- a/model/reporting.py
+++ b/model/reporting.py
@@ -896,8 +896,11 @@ class Reporting(object):
         # - NOTE: For this version, the channelStorage does not include floodVolume.
         
         # riverine flood inundation volume (unit: m3)
-        self.floodVolume = pcr.ifthen(self._model.routing.landmask, \
-                           pcr.cover(self._model.routing.floodInundationVolume, 0.0))
+        if self._model.routing.floodPlain:
+            self.floodVolume = pcr.ifthen(
+                self._model.routing.landmask,
+                pcr.cover(self._model.routing.floodInundationVolume, 0.0),
+            )
         
 
 

--- a/model/routing.py
+++ b/model/routing.py
@@ -905,21 +905,31 @@ class Routing(object):
                                        pcr.ifthen(self.lddMap == pcr.ldd(5), self.Q), 0.0))
         # TODO: accumulate water in endorheic basins that are considered as lakes/reservoirs
 
-                
-        # riverine flood volume (m3)
-        # - assume/simplify that lakes/reservoir cells never flooded 
-        self.floodInundationVolume = pcr.ifthenelse(pcr.cover(self.WaterBodies.waterBodyIds, 0) == 0,\
-                                                    pcr.max(0.0, self.channelStorage - self.channelStorageCapacity), 0.0)
-        #
-        # - ignore small floods with small or not significant inundation fractions:
-        self.floodInundationVolume = pcr.ifthenelse(self.dynamicFracWat > self.min_fracwat_for_water_height, self.floodInundationVolume, 0.0) 
-        self.floodInundationVolume = pcr.cover(self.floodInundationVolume, 0.0)
-        self.floodInundationVolume = pcr.max(0.0, pcr.min(self.channelStorage, self.floodInundationVolume))
-        self.floodInundationVolume = pcr.ifthen(self.landmask, self.floodInundationVolume)
-        #
-        #~ pcr.aguila(self.floodInundationVolume)
-        
-        			                  
+        if self.floodPlain:
+            # riverine flood volume (m3)
+            # - assume/simplify that lakes/reservoir cells never flooded
+            self.floodInundationVolume = pcr.ifthenelse(
+                pcr.cover(self.WaterBodies.waterBodyIds, 0) == 0,
+                pcr.max(0.0, self.channelStorage - self.channelStorageCapacity),
+                0.0,
+            )
+            #
+            # - ignore small floods with small or not significant inundation fractions:
+            self.floodInundationVolume = pcr.ifthenelse(
+                self.dynamicFracWat > self.min_fracwat_for_water_height,
+                self.floodInundationVolume,
+                0.0,
+            )
+            self.floodInundationVolume = pcr.cover(self.floodInundationVolume, 0.0)
+            self.floodInundationVolume = pcr.max(
+                0.0, pcr.min(self.channelStorage, self.floodInundationVolume)
+            )
+            self.floodInundationVolume = pcr.ifthen(
+                self.landmask, self.floodInundationVolume
+            )
+            #
+            #~ pcr.aguila(self.floodInundationVolume)
+
         # estimate volume of water that can be extracted for abstraction in the next time step
         self.readAvlChannelStorage = pcr.max(0.0, self.estimate_available_volume_for_abstraction(self.channelStorage))
         


### PR DESCRIPTION
This pull request fixes #8 by only running flood-plain calculations if `floodPlain` is `True`. This was already the case in most places, but there were a couple places where it was not the case.