### PR TITLE
Fix bug in reading input data.

### DIFF
--- a/model/virtualOS.py
+++ b/model/virtualOS.py
@@ -149,11 +149,9 @@ def netcdf2PCRobjCloneWithoutTime(ncFile, varName,
     factor = 1                                 # needed in regridData2FinerGrid
     if sameClone == False:
         # crop to cloneMap:
-        minX    = min(abs(f.variables['lon'][:] - (xULClone + 0.5*cellsizeInput))) # ; print(minX)
-        xIdxSta = int(np.where(abs(f.variables['lon'][:] - (xULClone + 0.5*cellsizeInput)) == minX)[0])
+        xIdxSta = np.argmin(abs(f.variables['lon'][:] - (xULClone + 0.5*cellsizeInput)))
         xIdxEnd = int(math.ceil(xIdxSta + colsClone /(cellsizeInput/cellsizeClone)))
-        minY    = min(abs(f.variables['lat'][:] - (yULClone - 0.5*cellsizeInput))) # ; print(minY)
-        yIdxSta = int(np.where(abs(f.variables['lat'][:] - (yULClone - 0.5*cellsizeInput)) == minY)[0])
+        yIdxSta = np.argmin(abs(f.variables['lat'][:] - (xULClone - 0.5*cellsizeInput)))
         yIdxEnd = int(math.ceil(yIdxSta + rowsClone /(cellsizeInput/cellsizeClone)))
         cropData = f.variables[varName][yIdxSta:yIdxEnd,xIdxSta:xIdxEnd]
         factor = int(round(float(cellsizeInput)/float(cellsizeClone)))


### PR DESCRIPTION
The following configuration exposes the bug:
``` Python
xULClone = 0.75
cellsizeInput = 0.75
lons = np.arange(0, 10, cellsizeInput)
print(lons)
>> array([0.  , 0.75, 1.5 , 2.25, 3.  , 3.75, 4.5 , 5.25, 6.  , 6.75, 7.5 , 8.25, 9.  , 9.75])
minX = np.min(np.abs(lons - xULClone - cellsizeInput/2))
print(minX)
>> 0.375
print(np.abs(lons - xULClone - cellsizeInput/2))
>> [1.125 0.375 0.375 1.125 1.875 2.625 3.375 4.125 4.875 5.625 6.375 7.125 7.875 8.625] # note that minX occurs twice!
print(np.where(np.abs(lons - (xULClone - cellsizeInput/2)) == minX))
>> (array([0, 1]),)
xIdxSta = np.where(np.abs(lons - (xULClone - cellsizeInput/2)) == minX)[0]
print(xIdxSta)
>> [0 1]
int(xIdxSta)
>> TypeError: only size-1 arrays can be converted to Python scalars
```

Note that the bug can easily be solved by adding one more pair of brackets: 
`xIdxSta = int(np.where(np.abs(lons - (xULClone - cellsizeInput/2)) == minX)[0][0])`

However, the proposed fix using `np.argmin` avoids the need to explicitly identify `minX` first and then identify the corresponding point with `np.where`. Note the [numpy docs](https://docs.scipy.org/doc/numpy/reference/generated/numpy.argmin.html): In case of multiple occurrences of the minimum values, the indices corresponding to the first occurrence are returned. Also, there is no need to convert to `int` explicitly, because that's the default return type of `np.argmin`.