### PR TITLE
Waterbody reporting bugfix

### DIFF
--- a/model/routing.py
+++ b/model/routing.py
@@ -1186,7 +1186,10 @@ class Routing(object):
         self.discharge = pcr.ifthen(self.landmask, self.discharge)
         #
         self.disChanWaterBody = pcr.ifthen(pcr.scalar(self.WaterBodies.waterBodyIds) > 0.,\
-                                pcr.areamaximum(self.discharge,self.WaterBodies.waterBodyIds))
+                                pcr.ifthen(self.WaterBodies.waterBodyOut, self.discharge))
+        self.disChanWaterBody = pcr.cover(self.disChanWaterBody, 0.0)
+        self.disChanWaterBody = pcr.ifthen(pcr.scalar(self.WaterBodies.waterBodyIds) > 0.,\
+                                pcr.areamaximum(self.disChanWaterBody,self.WaterBodies.waterBodyIds))
         self.disChanWaterBody = pcr.cover(self.disChanWaterBody, self.discharge)
         self.disChanWaterBody = pcr.ifthen(self.landmask, self.disChanWaterBody)
         #

--- a/model/routing.py
+++ b/model/routing.py
@@ -1631,7 +1631,10 @@ class Routing(object):
         self.discharge = pcr.ifthen(self.landmask, self.discharge)
         #
         self.disChanWaterBody = pcr.ifthen(pcr.scalar(self.WaterBodies.waterBodyIds) > 0.,\
-                                pcr.areamaximum(self.discharge,self.WaterBodies.waterBodyIds))
+                                pcr.ifthen(self.WaterBodies.waterBodyOut, self.discharge))
+        self.disChanWaterBody = pcr.cover(self.disChanWaterBody, 0.0)
+        self.disChanWaterBody = pcr.ifthen(pcr.scalar(self.WaterBodies.waterBodyIds) > 0.,\
+                                pcr.areamaximum(self.disChanWaterBody,self.WaterBodies.waterBodyIds))
         self.disChanWaterBody = pcr.cover(self.disChanWaterBody, self.discharge)
         self.disChanWaterBody = pcr.ifthen(self.landmask, self.disChanWaterBody)
         #
@@ -1906,7 +1909,10 @@ class Routing(object):
         self.discharge = pcr.ifthen(self.landmask, self.discharge)
         #
         self.disChanWaterBody = pcr.ifthen(pcr.scalar(self.WaterBodies.waterBodyIds) > 0.,\
-                                pcr.areamaximum(self.discharge,self.WaterBodies.waterBodyIds))
+                                pcr.ifthen(self.WaterBodies.waterBodyOut, self.discharge))
+        self.disChanWaterBody = pcr.cover(self.disChanWaterBody, 0.0)
+        self.disChanWaterBody = pcr.ifthen(pcr.scalar(self.WaterBodies.waterBodyIds) > 0.,\
+                                pcr.areamaximum(self.disChanWaterBody,self.WaterBodies.waterBodyIds))
         self.disChanWaterBody = pcr.cover(self.disChanWaterBody, self.discharge)
         self.disChanWaterBody = pcr.ifthen(self.landmask, self.disChanWaterBody)
         #
@@ -2167,7 +2173,10 @@ class Routing(object):
         self.discharge = pcr.ifthen(self.landmask, self.discharge)
         #
         self.disChanWaterBody = pcr.ifthen(pcr.scalar(self.WaterBodies.waterBodyIds) > 0.,\
-                                pcr.areamaximum(self.discharge,self.WaterBodies.waterBodyIds))
+                                pcr.ifthen(self.WaterBodies.waterBodyOut, self.discharge))
+        self.disChanWaterBody = pcr.cover(self.disChanWaterBody, 0.0)
+        self.disChanWaterBody = pcr.ifthen(pcr.scalar(self.WaterBodies.waterBodyIds) > 0.,\
+                                pcr.areamaximum(self.disChanWaterBody,self.WaterBodies.waterBodyIds))
         self.disChanWaterBody = pcr.cover(self.disChanWaterBody, self.discharge)
         self.disChanWaterBody = pcr.ifthen(self.landmask, self.disChanWaterBody)
         #


### PR DESCRIPTION
There is a bug in the reporting of the waterbody outflow in PCR-GLOBWB.

PCR-GLOBWB currently reports the waterbody discharge as the maximum discharge over the waterbody (see routing.py line 1188). However, during the routing, waterbody outflow is actually spread over the whole waterbody area (see routing.py line 1161). For larger waterbodies this means that the waterbody outflow may not actually leave the waterbody and is instead outflow transported _within_ the waterbody. This also means this water never actually leaves the waterbody, but is assimilated into the waterbody storage the next timestep (see routing.py line 1120).

While it might be considered to change this in the future (as it is incorrect), this also means that taking the maximum discharge over the waterbody is not indicative of the waterbody outflow. Especially in cases where the ldd converses inside a large waterbody. Therefore: waterbody_inflow - waterbody_outflow != waterbody_storage_change (note I have calculated this using PCR-GLOBWB output).

The change that I made now only reports the discharge at the waterbody outflow point as the waterbody discharge, and a simple water-balance check confirmed that now waterbody_inflow - waterbody_outflow == waterbody_storage_change.