### PR TITLE
Bugfix for regridding where coarse and fine resolution bounds do not match

### DIFF
--- a/model/virtualOS.py
+++ b/model/virtualOS.py
@@ -228,17 +228,77 @@ def singleTryNetcdf2PCRobjCloneWithoutTime(ncFile, varName,\
 
     # convert to PCR object and close f 
     if specificFillValue != None:
+        regridData = regridData2FinerGrid(factor, cropData, float(specificFillValue))
+        
+        if regridData.shape[-1] != colsClone or regridData.shape[-2] != rowsClone:
+            xULRegrid = f.variables['lon'][:][xIdxSta] - 0.5 * cellsizeInput
+            yULRegrid = f.variables['lat'][:][yIdxSta] + 0.5 * cellsizeInput
+            lonsRegrid = xULRegrid + np.arange(0, colsInput * factor) * cellsizeClone
+            latsRegrid = yULRegrid - np.arange(0, rowsInput * factor) * cellsizeClone
+            lonsRegrid += 0.5 * cellsizeClone
+            latsRegrid -= 0.5 * cellsizeClone
+            
+            # crop to cloneMap:
+            lonDiffRegrid = abs(lonsRegrid - (xULClone + 0.5 * cellsizeClone))
+            latDiffRegrid = abs(latsRegrid - (yULClone - 0.5 * cellsizeClone))
+            xIdxSta = int(np.where(lonDiffRegrid == min(lonDiffRegrid))[0])
+            xIdxEnd = int(math.ceil(xIdxSta + colsClone))
+            yIdxSta = int(np.where(latDiffRegrid == min(latDiffRegrid))[0])
+            yIdxEnd = int(math.ceil(yIdxSta + rowsClone))
+            
+            regridData = regridData[..., yIdxSta:yIdxEnd, xIdxSta:xIdxEnd]
+        
         outPCR = pcr.numpy2pcr(pcr.Scalar, \
-                  regridData2FinerGrid(factor, cropData, float(specificFillValue)), \
+                  regridData, \
                   float(specificFillValue))
     else:
         try:
+            regridData = regridData2FinerGrid(factor, cropData, float(f.variables[varName]._FillValue))
+        
+            if regridData.shape[-1] != colsClone or regridData.shape[-2] != rowsClone:
+                xULRegrid = f.variables['lon'][:][xIdxSta] - 0.5 * cellsizeInput
+                yULRegrid = f.variables['lat'][:][yIdxSta] + 0.5 * cellsizeInput
+                lonsRegrid = xULRegrid + np.arange(0, colsInput * factor) * cellsizeClone
+                latsRegrid = yULRegrid - np.arange(0, rowsInput * factor) * cellsizeClone
+                lonsRegrid += 0.5 * cellsizeClone
+                latsRegrid -= 0.5 * cellsizeClone
+                
+                # crop to cloneMap:
+                lonDiffRegrid = abs(lonsRegrid - (xULClone + 0.5 * cellsizeClone))
+                latDiffRegrid = abs(latsRegrid - (yULClone - 0.5 * cellsizeClone))
+                xIdxSta = int(np.where(lonDiffRegrid == min(lonDiffRegrid))[0])
+                xIdxEnd = int(math.ceil(xIdxSta + colsClone))
+                yIdxSta = int(np.where(latDiffRegrid == min(latDiffRegrid))[0])
+                yIdxEnd = int(math.ceil(yIdxSta + rowsClone))
+                
+                regridData = regridData[..., yIdxSta:yIdxEnd, xIdxSta:xIdxEnd]
+        
             outPCR = pcr.numpy2pcr(pcr.Scalar, \
-                  regridData2FinerGrid(factor, cropData, float(f.variables[varName]._FillValue)), \
+                  regridData, \
                   float(f.variables[varName]._FillValue))
         except:
+            regridData = regridData2FinerGrid(factor, cropData, float(f.variables[varName].missing_value))
+            
+            if regridData.shape[-1] != colsClone or regridData.shape[-2] != rowsClone:
+                xULRegrid = f.variables['lon'][:][xIdxSta] - 0.5 * cellsizeInput
+                yULRegrid = f.variables['lat'][:][yIdxSta] + 0.5 * cellsizeInput
+                lonsRegrid = xULRegrid + np.arange(0, colsInput * factor) * cellsizeClone
+                latsRegrid = yULRegrid - np.arange(0, rowsInput * factor) * cellsizeClone
+                lonsRegrid += 0.5 * cellsizeClone
+                latsRegrid -= 0.5 * cellsizeClone
+                
+                # crop to cloneMap:
+                lonDiffRegrid = abs(lonsRegrid - (xULClone + 0.5 * cellsizeClone))
+                latDiffRegrid = abs(latsRegrid - (yULClone - 0.5 * cellsizeClone))
+                xIdxSta = int(np.where(lonDiffRegrid == min(lonDiffRegrid))[0])
+                xIdxEnd = int(math.ceil(xIdxSta + colsClone))
+                yIdxSta = int(np.where(latDiffRegrid == min(latDiffRegrid))[0])
+                yIdxEnd = int(math.ceil(yIdxSta + rowsClone))
+                
+                regridData = regridData[..., yIdxSta:yIdxEnd, xIdxSta:xIdxEnd]
+            
             outPCR = pcr.numpy2pcr(pcr.Scalar, \
-                  regridData2FinerGrid(factor, cropData, float(f.variables[varName].missing_value)), \
+                  regridData, \
                   float(f.variables[varName].missing_value))
 
     #~ # debug:
@@ -851,17 +911,79 @@ def singleTryNetcdf2PCRobjClone(ncFile,\
 
     # convert to PCR object and close f 
     if specificFillValue != None:
+        regridData = regridData2FinerGrid(factor, cropData, float(specificFillValue))
+        
+        if regridData.shape[-1] != colsClone or regridData.shape[-2] != rowsClone:
+            xULRegrid = f.variables['lon'][:][xIdxSta] - 0.5 * cellsizeInput
+            yULRegrid = f.variables['lat'][:][yIdxSta] + 0.5 * cellsizeInput
+            lonsRegrid = xULRegrid + np.arange(0, colsInput * factor) * cellsizeClone
+            latsRegrid = yULRegrid - np.arange(0, rowsInput * factor) * cellsizeClone
+            lonsRegrid += 0.5 * cellsizeClone
+            latsRegrid -= 0.5 * cellsizeClone
+            
+            # crop to cloneMap:
+            lonDiffRegrid = abs(lonsRegrid - (xULClone + 0.5 * cellsizeClone))
+            latDiffRegrid = abs(latsRegrid - (yULClone - 0.5 * cellsizeClone))
+            xIdxSta = int(np.where(lonDiffRegrid == min(lonDiffRegrid))[0])
+            xIdxEnd = int(math.ceil(xIdxSta + colsClone))
+            yIdxSta = int(np.where(latDiffRegrid == min(latDiffRegrid))[0])
+            yIdxEnd = int(math.ceil(yIdxSta + rowsClone))
+            
+            regridData = regridData[yIdxSta:yIdxEnd, xIdxSta:xIdxEnd]
+        
         outPCR = pcr.numpy2pcr(pcr.Scalar, \
-                  regridData2FinerGrid(factor, cropData, float(specificFillValue)), \
+                  regridData, \
                   float(specificFillValue))
     else:
         try:
+            
+            regridData = regridData2FinerGrid(factor, cropData, float(f.variables[varName]._FillValue))
+
+            if regridData.shape[-1] != colsClone or regridData.shape[-2] != rowsClone:
+                xULRegrid = f.variables['lon'][:][xIdxSta] - 0.5 * cellsizeInput
+                yULRegrid = f.variables['lat'][:][yIdxSta] + 0.5 * cellsizeInput
+                lonsRegrid = xULRegrid + np.arange(0, colsInput * factor) * cellsizeClone
+                latsRegrid = yULRegrid - np.arange(0, rowsInput * factor) * cellsizeClone
+                lonsRegrid += 0.5 * cellsizeClone
+                latsRegrid -= 0.5 * cellsizeClone
+                
+                # crop to cloneMap:
+                lonDiffRegrid = abs(lonsRegrid - (xULClone + 0.5 * cellsizeClone))
+                latDiffRegrid = abs(latsRegrid - (yULClone - 0.5 * cellsizeClone))
+                xIdxSta = int(np.where(lonDiffRegrid == min(lonDiffRegrid))[0])
+                xIdxEnd = int(math.ceil(xIdxSta + colsClone))
+                yIdxSta = int(np.where(latDiffRegrid == min(latDiffRegrid))[0])
+                yIdxEnd = int(math.ceil(yIdxSta + rowsClone))
+                
+                regridData = regridData[..., yIdxSta:yIdxEnd, xIdxSta:xIdxEnd]
+            
             outPCR = pcr.numpy2pcr(pcr.Scalar, \
-                  regridData2FinerGrid(factor, cropData, float(f.variables[varName]._FillValue)), \
+                  regridData, \
                   float(f.variables[varName]._FillValue))
         except:
+            
+            regridData = regridData2FinerGrid(factor, cropData, float(f.variables[varName].missing_value))
+            
+            if regridData.shape[-1] != colsClone or regridData.shape[-2] != rowsClone:
+                xULRegrid = f.variables['lon'][:][xIdxSta] - 0.5 * cellsizeInput
+                yULRegrid = f.variables['lat'][:][yIdxSta] + 0.5 * cellsizeInput
+                lonsRegrid = xULRegrid + np.arange(0, colsInput * factor) * cellsizeClone
+                latsRegrid = yULRegrid - np.arange(0, rowsInput * factor) * cellsizeClone
+                lonsRegrid += 0.5 * cellsizeClone
+                latsRegrid -= 0.5 * cellsizeClone
+                
+                # crop to cloneMap:
+                lonDiffRegrid = abs(lonsRegrid - (xULClone + 0.5 * cellsizeClone))
+                latDiffRegrid = abs(latsRegrid - (yULClone - 0.5 * cellsizeClone))
+                xIdxSta = int(np.where(lonDiffRegrid == min(lonDiffRegrid))[0])
+                xIdxEnd = int(math.ceil(xIdxSta + colsClone))
+                yIdxSta = int(np.where(latDiffRegrid == min(latDiffRegrid))[0])
+                yIdxEnd = int(math.ceil(yIdxSta + rowsClone))
+                
+                regridData = regridData[..., yIdxSta:yIdxEnd, xIdxSta:xIdxEnd]
+            
             outPCR = pcr.numpy2pcr(pcr.Scalar, \
-                  regridData2FinerGrid(factor, cropData, float(f.variables[varName].missing_value)), \
+                  regridData, \
                   float(f.variables[varName].missing_value))
 
     #~ pcr.aguila(outPCR)


### PR DESCRIPTION
When regridding a course resolution (netCDF) array, a factor is applied and the array is uniformly downscaled based on this factor. However, for cases where the fine resolution bounds to not match up with the coarse resolution bounds, this will not work. Rather the regridded coarse resolution array will be too large.

This branch fixes this issue by, if necessary, cropping the regridded data to the fine resolution bounds. *Note that this fix is only applied to the default netcdf loading functions 'singleTryNetcdf2PCRobjCloneWithoutTime' and 'singleTryNetcdf2PCRobjClone'.* In the future it would be better to reorganize the code so that this is done in a single function.