### PR TITLE
Add linting (code formatting) action to the PCR-GLOBWB_model master branch

### DIFF
--- a/.github/workflows/code_formatting.yml
+++ b/.github/workflows/code_formatting.yml
@@ -1,0 +1,34 @@
+name: Code formatting
+
+on: 
+  push:
+    branches: [master]
+
+jobs:
+  linting:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.head_ref }}
+      - name: "Run isort"
+        uses: isort/isort-action@v1
+        with:
+          configuration: ""
+        continue-on-error: true
+      - name: Run Black
+        id: black
+        uses: psf/black@stable
+        with:
+          options: "--verbose"
+          src: "."
+        continue-on-error: true
+      - name: Commit changes
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add .
+          git commit -m "automatically generated isort and black linting"
+          git push


### PR DESCRIPTION
[GitHub Actions](https://docs.github.com/en/actions) are automated processes that fire during any GitHub action, such as push or pull request. I have added a GitHub action that automatically lints the code in the repository using [isort](https://pycqa.github.io/isort/) for the python imports and [black](https://black.readthedocs.io/en/stable/index.html) for the code, **for any push to the master branch**. It does so by automatically generating another commit with the fixes to the code.

This GitHub Action integration will help maintain a clear an structured code-base and fixes issues #30, #29 and #28 automatically (also in the future).

Possible downsides:
1. Strict black formatting applied
2. New commit after every push (so maybe make development branch, in line with issue #37)